### PR TITLE
Ubuntu 19.10: Bugfix missing PPA

### DIFF
--- a/vars/ubuntu-19.10.yml
+++ b/vars/ubuntu-19.10.yml
@@ -14,8 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-_apt_repository:
-  - { state: "present", repo: "ppa:duplicity-team/ppa" }
+_apt_repository: []
 
 _apt:
   - { state: "latest", name: "duplicity" }


### PR DESCRIPTION
Duplicity PPA don't have eoan support, let's use the official upstream
package.